### PR TITLE
Fix pantry item update

### DIFF
--- a/cookbook-engine/src/lib.rs
+++ b/cookbook-engine/src/lib.rs
@@ -792,7 +792,9 @@ impl DataManager {
         if let Some(index) = pantry_item_index {
             // Update the existing pantry item
             pantry.items[index].quantity = quantity;
-            pantry.items[index].quantity_type = quantity_type.unwrap_or_default();
+            if let Some(qt) = quantity_type {
+                pantry.items[index].quantity_type = qt;
+            }
             pantry.items[index].last_updated = today;
         } else {
             // Create a new pantry item


### PR DESCRIPTION
## Summary
- fix update_pantry_item to preserve quantity_type when not provided

## Testing
- `cargo check --workspace --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6847082c380c8327b7b5e1f23e44fdee